### PR TITLE
[bugfix-128] mysql 에러구문 변환시 조건 추가

### DIFF
--- a/sejongsql/module/environ.py
+++ b/sejongsql/module/environ.py
@@ -167,9 +167,13 @@ def run_problem(env, query):
         query_result = validator_result.msg
         query_result = query_result.replace(f"{env.db_name}.", "")
         query_result = query_result.replace(env.db_name, "")
-        index = query_result.index('"') + 1
-        query_result = query_result[index: -2]
-    
+        index_1 = query_result.find('"')
+        index_2 = query_result.find("'")
+        if index_1 != -1: # 쌍따옴표로 감싸진 mysql error문
+            query_result = query_result[index_1+1: -2]
+        elif index_2 != -1: #따옴표로 감싸진 mysql error문
+            query_result = query_result[index_2+1: -2]
+        
     return status, query_result
 
 


### PR DESCRIPTION
close #128 

조건: 쌍따옴표와 따옴표로 구분

1. 쌍따옴표일 때
    - 에러구문 안에 따옴표가 존재함
    - 내부의 따옴표는 건드리지 않고 변환
2. 따옴표일 때
    - 그냥 변환

validator에서 걸리는 unsafe query는 에러구문 그대로 반환.
