### PR TITLE
[bugfix-130] 분반 반환시, class_id 고정되는 문제

### DIFF
--- a/sejongsql/app_main/views/classes.py
+++ b/sejongsql/app_main/views/classes.py
@@ -64,6 +64,7 @@ class ClassView(APIView):
         else:
             if data['class_id']:
                 classes = Class.objects.filter(
+                    Q(id=data['class_id']),
                     Q(userbelongclass__user_id=user.id),
                     Q(userbelongclass__type='prof') |
                     Q(userbelongclass__type='ta') |


### PR DESCRIPTION
class_id가 존재할 경우, 해당 class_id로 찾아서 반환해줘야 하는데, 그냥 전체 class중에서 제일 위에꺼를 반환해주고 있었음.